### PR TITLE
feat: use DI for IRestClient to allow your own implementation

### DIFF
--- a/Indicia.HubSpot/Core/HubSpotClient.cs
+++ b/Indicia.HubSpot/Core/HubSpotClient.cs
@@ -16,7 +16,7 @@ namespace Indicia.HubSpot.Core
     internal class HubSpotClient : IHubSpotClient
     {
         private readonly IOptions<HubSpotOptions> _options;
-        private readonly RestClient _client;
+        private readonly IRestClient _client;
         private readonly ILogger _logger;
 
         private static string BaseUrl => "https://api.hubapi.com";
@@ -28,7 +28,10 @@ namespace Indicia.HubSpot.Core
         public HubSpotClient(IOptions<HubSpotOptions> options, IServiceProvider serviceProvider)
         {
             _options = options;
-            _client = new RestClient(BaseUrl);
+
+            _client = serviceProvider.GetRequiredService<IRestClient>();
+            _client.BaseUrl = new Uri(BaseUrl);
+
             _logger = _options.Value.UseHttpLogging ? serviceProvider.GetService<ILogger>() : null;
 
             if (_options.Value.Auth == null)

--- a/Indicia.HubSpot/Support/ServiceCollectionExtensions.cs
+++ b/Indicia.HubSpot/Support/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Indicia.HubSpot.Api.Tickets;
 using Indicia.HubSpot.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using RestSharp;
 
 namespace Indicia.HubSpot.Support
 {
@@ -19,6 +20,7 @@ namespace Indicia.HubSpot.Support
                 services.Configure(hubSpotOptionsAction);
             }
 
+            services.TryAddSingleton<IRestClient, RestClient>();
             services.TryAddSingleton<IHubSpotApi, HubSpotApi>();
             services.TryAddSingleton<IHubSpotClient, HubSpotClient>();
 

--- a/README.md
+++ b/README.md
@@ -99,4 +99,16 @@ public class HubSpotTestCommand
 }
 ```
 
+### Use your own _IRestClient_
+
+It is possible to register your own `IRestClient` implementation instead of the default one from RestSharp. For example, this allows extending
+the `RestClient` class with retry policies using Polly. Just register your own implementation before calling `services.AddHubSpot(...)`:
+
+```csharp
+services.AddSingleton<IRestClient, MyAwesomeRestClient>();
+services.AddHubSpot(options =>
+{
+    options.Auth = new HubSpotApiKeyClientAuth("YOUR-API-KEY");
+});
+```
 


### PR DESCRIPTION
For example to enable retry policies using Polly.